### PR TITLE
feat: Align with MCP Python SDK best practices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,10 @@ WORKDIR /app
 # Environment variables
 ENV UV_COMPILE_BYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PYTHONDONTWRITEBYTECODE=1
+    PYTHONDONTWRITEBYTECODE=1 \
+    # MCP server defaults for HTTP transports
+    MCP_HOST=0.0.0.0 \
+    MCP_PORT=8000
 
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
@@ -31,5 +34,5 @@ ENTRYPOINT ["uv", "run", "src/server.py"]
 
 # Default arguments (can be overridden)
 # For stdio (default MCP transport): no args needed
-# For HTTP: --transport streamable-http --host 0.0.0.0 --port 8000
+# For HTTP: --transport streamable-http
 CMD ["--transport", "stdio"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
   # Usage: docker-compose up mcp-trino-http
   mcp-trino-http:
     build: .
-    command: ["--transport", "streamable-http", "--host", "0.0.0.0", "--port", "8000"]
+    command: ["--transport", "streamable-http"]
     ports:
       - "8000:8000"
     environment:
@@ -24,6 +24,8 @@ services:
       - TRINO_USER=trino
       - TRINO_CATALOG=tpch
       - TRINO_SCHEMA=tiny
+      - MCP_HOST=0.0.0.0
+      - MCP_PORT=8000
     depends_on:
       trino:
         condition: service_healthy
@@ -35,7 +37,7 @@ services:
   # Usage: docker-compose --profile sse up mcp-trino-sse
   mcp-trino-sse:
     build: .
-    command: ["--transport", "sse", "--host", "0.0.0.0", "--port", "8000"]
+    command: ["--transport", "sse"]
     ports:
       - "8001:8000"
     environment:
@@ -44,6 +46,8 @@ services:
       - TRINO_USER=trino
       - TRINO_CATALOG=tpch
       - TRINO_SCHEMA=tiny
+      - MCP_HOST=0.0.0.0
+      - MCP_PORT=8000
     depends_on:
       trino:
         condition: service_healthy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-trino-python"
-version = "0.7.0"
+version = "0.7.1"
 description = "A Model Context Protocol (MCP) connector for Trino, enabling seamless integration between MCP-compliant services and Trino query engine"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## Summary

This PR aligns the project with MCP Python SDK best practices based on analysis of the official SDK repository.

## Changes

### server.py
- FastMCP now initialized with \host\, \port\, \stateless_http=True\, \json_response=True\
- Configuration via \MCP_HOST\/\MCP_PORT\ environment variables with defaults (127.0.0.1:8000)
- Transport handling uses \mcp.settings\ for dynamic configuration updates

### Dockerfile
- Added \MCP_HOST=0.0.0.0\ and \MCP_PORT=8000\ environment variables
- Simplified CMD (removed redundant --host/--port args)

### docker-compose.yml
- Services now use environment variables instead of CLI arguments
- Cleaner, more maintainable configuration

## SDK Best Practices Applied
- Settings-based configuration over CLI arguments
- Environment variable support for containerized deployments
- \stateless_http=True\ for better HTTP transport behavior
- \json_response=True\ for consistent response formatting